### PR TITLE
Add skill detail page and link skill bars

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -406,6 +406,7 @@ a.rotate-box-1:hover, a.rotate-box-2:hover {
 
 /* ===== Begin progress bar ===== */
 .skill-bar {
+        display: block;
 }
 .progress {
 	overflow: visible;

--- a/index.html
+++ b/index.html
@@ -222,8 +222,8 @@
                 	<div class="container">
                     	<div class="row">
                         
-                        	<div class="col-sm-6">
-                                <div class="skill-bar wow slideInLeft" data-wow-delay="0.2s">
+                                <div class="col-sm-6">
+                                <a href="skills_detail.html#networking" class="skill-bar wow slideInLeft" data-wow-delay="0.2s">
                                     <div class="progress-lebel">
                                         <h6>Networking</h6>
                                     </div>
@@ -231,11 +231,11 @@
                                       <div class="progress-bar" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%;">
                                       </div>
                                     </div>
-                                </div>
+                                </a>
                             </div>
                             
                             <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.2s">
+                                <a href="skills_detail.html#windows" class="skill-bar wow slideInRight" data-wow-delay="0.2s">
                                     <div class="progress-lebel">
                                         <h6>Windows</h6>
                                     </div>
@@ -243,11 +243,11 @@
                                       <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;">
                                       </div>
                                     </div>
-                                </div>
+                                </a>
                             </div>
                             
                             <div class="col-sm-6">
-                                <div class="skill-bar wow slideInLeft" data-wow-delay="0.4s">
+                                <a href="skills_detail.html#html-css" class="skill-bar wow slideInLeft" data-wow-delay="0.4s">
                                     <div class="progress-lebel">
                                         <h6>Html & Css</h6>
                                     </div>
@@ -255,11 +255,11 @@
                                       <div class="progress-bar" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%;">
                                       </div>
                                     </div>
-                                </div>
+                                </a>
                             </div>
                             
                             <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
+                                <a href="skills_detail.html#javascript" class="skill-bar wow slideInRight" data-wow-delay="0.4s">
                                     <div class="progress-lebel">
                                         <h6>Javascript</h6>
                                     </div>
@@ -267,10 +267,10 @@
                                       <div class="progress-bar" role="progressbar" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100" style="width: 30%;">
                                       </div>
                                     </div>
-                                </div>
+                                </a>
                             </div>
                             <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
+                                <a href="skills_detail.html#linux" class="skill-bar wow slideInRight" data-wow-delay="0.4s">
                                     <div class="progress-lebel">
                                         <h6>Linux</h6>
                                     </div>
@@ -278,10 +278,10 @@
                                       <div class="progress-bar" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%;">
                                       </div>
                                     </div>
-                                </div>
+                                </a>
                             </div>
                             <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
+                                <a href="skills_detail.html#cybersecurity" class="skill-bar wow slideInRight" data-wow-delay="0.4s">
                                     <div class="progress-lebel">
                                         <h6>Cybersecurity</h6>
                                     </div>
@@ -289,10 +289,10 @@
                                       <div class="progress-bar" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%;">
                                       </div>
                                     </div>
-                                </div>
+                                </a>
                             </div>
                             <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
+                                <a href="skills_detail.html#mysql" class="skill-bar wow slideInRight" data-wow-delay="0.4s">
                                     <div class="progress-lebel">
                                         <h6>MySQL</h6>
                                     </div>
@@ -300,10 +300,10 @@
                                       <div class="progress-bar" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%;">
                                       </div>
                                     </div>
-                                </div>
+                                </a>
                             </div>
                             <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
+                                <a href="skills_detail.html#python" class="skill-bar wow slideInRight" data-wow-delay="0.4s">
                                     <div class="progress-lebel">
                                         <h6>Python</h6>
                                     </div>
@@ -311,10 +311,10 @@
                                       <div class="progress-bar" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%;">
                                       </div>
                                     </div>
-                                </div>
+                                </a>
                             </div>
                             <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
+                                <a href="skills_detail.html#telecoms" class="skill-bar wow slideInRight" data-wow-delay="0.4s">
                                     <div class="progress-lebel">
                                         <h6>Telecoms</h6>
                                     </div>
@@ -322,7 +322,7 @@
                                       <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;">
                                       </div>
                                     </div>
-                                </div>
+                                </a>
                             </div>
                             
                         </div> <!-- /.row -->

--- a/skills_detail.html
+++ b/skills_detail.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Skills Details</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>My Skills in Detail</h1>
+    </header>
+    <section id="networking">
+        <h2>Networking</h2>
+        <p>Experience with network configuration, routing protocols and troubleshooting.</p>
+    </section>
+    <section id="windows">
+        <h2>Windows</h2>
+        <p>Proficient with Windows administration and system management.</p>
+    </section>
+    <section id="html-css">
+        <h2>HTML &amp; CSS</h2>
+        <p>Knowledge of front-end development using HTML and CSS.</p>
+    </section>
+    <section id="javascript">
+        <h2>Javascript</h2>
+        <p>Familiar with JavaScript for interactive web features.</p>
+    </section>
+    <section id="linux">
+        <h2>Linux</h2>
+        <p>Comfortable with Linux environments and shell scripting.</p>
+    </section>
+    <section id="cybersecurity">
+        <h2>Cybersecurity</h2>
+        <p>Understanding of cybersecurity principles and best practices.</p>
+    </section>
+    <section id="mysql">
+        <h2>MySQL</h2>
+        <p>Practical experience with MySQL database design and queries.</p>
+    </section>
+    <section id="python">
+        <h2>Python</h2>
+        <p>Proficient in Python for scripting and application development.</p>
+    </section>
+    <section id="telecoms">
+        <h2>Telecoms</h2>
+        <p>Basics of telecommunications systems and protocols.</p>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- make skill bars clickable by linking to a new detailed skills page
- ensure skill bar layout works for anchors
- add `skills_detail.html` describing each skill

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a8f91da7c832389fdb07eb7ac5855