### PR TITLE
Add detailed pages for experiences and certifications

### DIFF
--- a/base_donnees.html
+++ b/base_donnees.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Base de données</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Base de données</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Informations détaillées sur mes compétences en base de données.</p>
+    </section>
+</body>
+</html>

--- a/ccna.html
+++ b/ccna.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cisco CCNA</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Cisco CCNA</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Informations détaillées sur la certification Cisco CCNA.</p>
+    </section>
+</body>
+</html>

--- a/csna.html
+++ b/csna.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Stormshield CSNA</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Stormshield CSNA</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Informations détaillées sur la certification Stormshield CSNA.</p>
+    </section>
+</body>
+</html>

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -249,10 +249,10 @@
 		margin-bottom: 50px;
 	}
 
-	/* Partners & Foter */
-	#partners-section, footer {
-		text-align: center;
-	}
+        /* Certifications & Footer */
+        #certifications-section, footer {
+                text-align: center;
+        }
 
 	/* Hiding elements */
 	.testimonial:before,

--- a/css/skin/cool-gray.css
+++ b/css/skin/cool-gray.css
@@ -138,7 +138,7 @@ a, a:hover, a:focus {
 
 
 /* === CTA Section, Social & Partners === */
-#cta-section, #partners-section, #social-section {
+#cta-section, #certifications-section, #social-section {
 	background: #f8f8f8 url('../../img/pat-bg.png') repeat;
 }
 

--- a/css/skin/fresh-lime.css
+++ b/css/skin/fresh-lime.css
@@ -138,7 +138,7 @@ a, a:hover, a:focus {
 
 
 /* === CTA Section, Social & Partners === */
-#cta-section, #partners-section, #social-section {
+#cta-section, #certifications-section, #social-section {
 	background: #f8f8f8 url('../../img/pat-bg.png') repeat;
 }
 

--- a/css/skin/ice-blue.css
+++ b/css/skin/ice-blue.css
@@ -138,7 +138,7 @@ a, a:hover, a:focus {
 
 
 /* === CTA Section, Social & Partners === */
-#cta-section, #partners-section, #social-section {
+#cta-section, #certifications-section, #social-section {
 	background: #f8f8f8 url('../../img/pat-bg.png') repeat;
 }
 

--- a/css/skin/night-purple.css
+++ b/css/skin/night-purple.css
@@ -138,7 +138,7 @@ a, a:hover, a:focus {
 
 
 /* === CTA Section, Social & Partners === */
-#cta-section, #partners-section, #social-section {
+#cta-section, #certifications-section, #social-section {
 	background: #f8f8f8 url('../../img/pat-bg.png') repeat;
 }
 

--- a/css/skin/summer-orange.css
+++ b/css/skin/summer-orange.css
@@ -138,7 +138,7 @@ a, a:hover, a:focus {
 
 
 /* === CTA Section, Social & Partners === */
-#cta-section, #partners-section, #social-section {
+#cta-section, #certifications-section, #social-section {
 	background: #f8f8f8 url('../../img/pat-bg.png') repeat;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -406,6 +406,7 @@ a.rotate-box-1:hover, a.rotate-box-2:hover {
 
 /* ===== Begin progress bar ===== */
 .skill-bar {
+        display: block;
 }
 .progress {
 	overflow: visible;
@@ -704,19 +705,21 @@ a.rotate-box-1:hover, a.rotate-box-2:hover {
 /* ===== End team ===== */
 
 
-/* ===== Begin partners ===== */
-#partners-section {
-	padding: 80px 0;
+/* ===== Begin certifications ===== */
+#certifications-section {
+        padding: 80px 0;
 }
-.partners {
-	background-color: #252320;
+.cert-entry {
+        text-align: center;
+        padding: 15px;
 }
-
-.partners img {
-	max-width: 100%;
-	padding: 0 15px;
+.cert-logo {
+        max-width: 100%;
+        height: 75px;
+        margin-bottom: 15px;
+        object-fit: contain;
 }
-/* ===== End partners ===== */
+/* ===== End certifications ===== */
 
 
 /* ===== Begin panels ===== */
@@ -1121,10 +1124,26 @@ p.subtitle {
 	transform: rotate(45deg);
 }
 .scrolltotop .fa {
-	padding-left: 4px;
-	-webkit-transform: rotate(-45deg);
-	-moz-transform: rotate(-45deg);
-	-o-transform: rotate(-45deg);
-	transform: rotate(-45deg);
+        padding-left: 4px;
+        -webkit-transform: rotate(-45deg);
+        -moz-transform: rotate(-45deg);
+        -o-transform: rotate(-45deg);
+        transform: rotate(-45deg);
 }
 /* ===== End buttons ===== */
+
+/* Education and experience logos */
+.education-entry, .experience-entry {
+    margin-bottom: 30px;
+}
+.edu-logo, .exp-logo {
+    max-width: 100%;
+    height: 75px;
+    margin-bottom: 15px;
+    object-fit: contain;
+}
+.exp-link, .cert-link {
+    display: block;
+    color: inherit;
+    text-decoration: none;
+}

--- a/cybersecurite.html
+++ b/cybersecurite.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cybersécurité</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Cybersécurité</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Informations détaillées sur mes compétences en cybersécurité.</p>
+    </section>
+</body>
+</html>

--- a/exp_4connect.html
+++ b/exp_4connect.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>4Connect - Network and System Technician</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>4Connect</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Network and System Technician from 17 mars to 29 aout.</p>
+    </section>
+</body>
+</html>

--- a/exp_network_technician.html
+++ b/exp_network_technician.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Network and System Technician</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Network and System Technician</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Implemented an Active Directory service in 2024.</p>
+    </section>
+</body>
+</html>

--- a/exp_order_picker.html
+++ b/exp_order_picker.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Order Picker Experience</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Order Picker</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Handled stock management tasks in 2022.</p>
+    </section>
+</body>
+</html>

--- a/exp_wok_udon.html
+++ b/exp_wok_udon.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>WOK UDON Experience</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>WOK UDON</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Restaurant waiter during the summer of 2021.</p>
+    </section>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -222,108 +222,61 @@
                 	<div class="container">
                     	<div class="row">
                         
-                        	<div class="col-sm-6">
-                                <div class="skill-bar wow slideInLeft" data-wow-delay="0.2s">
-                                    <div class="progress-lebel">
-                                        <h6>Networking</h6>
-                                    </div>
-                                    <div class="progress">
-                                      <div class="progress-bar" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%;">
-                                      </div>
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.2s">
-                                    <div class="progress-lebel">
-                                        <h6>Windows</h6>
-                                    </div>
-                                    <div class="progress">
-                                      <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;">
-                                      </div>
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <div class="col-sm-6">
-                                <div class="skill-bar wow slideInLeft" data-wow-delay="0.4s">
-                                    <div class="progress-lebel">
-                                        <h6>Html & Css</h6>
-                                    </div>
-                                    <div class="progress">
-                                      <div class="progress-bar" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%;">
-                                      </div>
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
-                                    <div class="progress-lebel">
-                                        <h6>Javascript</h6>
-                                    </div>
-                                    <div class="progress">
-                                      <div class="progress-bar" role="progressbar" aria-valuenow="30" aria-valuemin="0" aria-valuemax="100" style="width: 30%;">
-                                      </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
-                                    <div class="progress-lebel">
-                                        <h6>Linux</h6>
-                                    </div>
-                                    <div class="progress">
-                                      <div class="progress-bar" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%;">
-                                      </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
-                                    <div class="progress-lebel">
-                                        <h6>Cybersecurity</h6>
-                                    </div>
-                                    <div class="progress">
-                                      <div class="progress-bar" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%;">
-                                      </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
-                                    <div class="progress-lebel">
-                                        <h6>MySQL</h6>
-                                    </div>
-                                    <div class="progress">
-                                      <div class="progress-bar" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%;">
-                                      </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
-                                    <div class="progress-lebel">
-                                        <h6>Python</h6>
-                                    </div>
-                                    <div class="progress">
-                                      <div class="progress-bar" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%;">
-                                      </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="col-sm-6">
-                                <div class="skill-bar wow slideInRight" data-wow-delay="0.4s">
-                                    <div class="progress-lebel">
-                                        <h6>Telecoms</h6>
-                                    </div>
-                                    <div class="progress">
-                                      <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;">
-                                      </div>
-                                    </div>
-                                </div>
-                            </div>
+            <div class="col-sm-6">
+                <a href="cybersecurite.html" class="skill-bar wow slideInLeft" data-wow-delay="0.2s">
+                    <div class="progress-lebel">
+                        <h6>Cybersécurité</h6>
+                    </div>
+                    <div class="progress">
+                      <div class="progress-bar" role="progressbar" aria-valuenow="80" aria-valuemin="0" aria-valuemax="100" style="width: 80%;">
+                      </div>
+                    </div>
+                </a>
+            </div>
+            <div class="col-sm-6">
+                <a href="reseaux.html" class="skill-bar wow slideInRight" data-wow-delay="0.2s">
+                    <div class="progress-lebel">
+                        <h6>Réseaux</h6>
+                    </div>
+                    <div class="progress">
+                      <div class="progress-bar" role="progressbar" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100" style="width: 75%;">
+                      </div>
+                    </div>
+                </a>
+            </div>
+            <div class="col-sm-6">
+                <a href="telecommunications.html" class="skill-bar wow slideInLeft" data-wow-delay="0.4s">
+                    <div class="progress-lebel">
+                        <h6>Télécommunications</h6>
+                    </div>
+                    <div class="progress">
+                      <div class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;">
+                      </div>
+                    </div>
+                </a>
+            </div>
+            <div class="col-sm-6">
+                <a href="systemes.html" class="skill-bar wow slideInRight" data-wow-delay="0.4s">
+                    <div class="progress-lebel">
+                        <h6>Systèmes</h6>
+                    </div>
+                    <div class="progress">
+                      <div class="progress-bar" role="progressbar" aria-valuenow="70" aria-valuemin="0" aria-valuemax="100" style="width: 70%;">
+                      </div>
+                    </div>
+                </a>
+            </div>
+            <div class="col-sm-6">
+                <a href="base_donnees.html" class="skill-bar wow slideInLeft" data-wow-delay="0.4s">
+                    <div class="progress-lebel">
+                        <h6>Base de données</h6>
+                    </div>
+                    <div class="progress">
+                      <div class="progress-bar" role="progressbar" aria-valuenow="65" aria-valuemin="0" aria-valuemax="100" style="width: 65%;">
+                      </div>
+                    </div>
+                </a>
+            </div>
                             
                         </div> <!-- /.row -->
                     </div> <!-- /.container -->
@@ -375,59 +328,50 @@
                 </div>
                 <!-- End page header-->
             
-                <!-- Begin roatet box-2 -->
-                <div class="rotate-box-2-wrapper">
+                <!-- Begin education logos -->
+                <div class="education-wrapper">
                     <div class="container">
                         <div class="row">
                             <div class="col-md-3 col-sm-6">
-                                <a href="#" class="rotate-box-2 square-icon text-center wow zoomIn" data-wow-delay="0">
-                                    <span class="rotate-box-icon"><i class="fa fa-leaf"></i></span>
-                                    <div class="rotate-box-info">
-                                        <h4>Longchamp Public Middle School</h4>
-                                        <p>2014 - 2018</p>
-                                    </div>
-                                </a>
+                                <div class="education-entry text-center wow zoomIn" data-wow-delay="0">
+                                    <img src="img/portfolio/p1.jpg" alt="Longchamp Public Middle School logo" class="edu-logo img-responsive center-block">
+                                    <h4>Longchamp Public Middle School</h4>
+                                    <p>2014 - 2018</p>
+                                </div>
                             </div>
-            
+
                             <div class="col-md-3 col-sm-6">
-                                <a href="#" class="rotate-box-2 square-icon text-center wow zoomIn" data-wow-delay="0.2s">
-                                    <span class="rotate-box-icon"><i class="fa fa-pie-chart"></i></span>
-                                    <div class="rotate-box-info">
-                                        <h4>High School of Rempart</h4>
-                                        <p>2019 - 2021</p>
-                                        <p>High School Diploma in Science and Technology for Industry and Sustainable Development</p>
-                                    </div>
-                                </a>
+                                <div class="education-entry text-center wow zoomIn" data-wow-delay="0.2s">
+                                    <img src="img/portfolio/p2.jpg" alt="High School of Rempart logo" class="edu-logo img-responsive center-block">
+                                    <h4>High School of Rempart</h4>
+                                    <p>2019 - 2021</p>
+                                    <p>High School Diploma in Science and Technology for Industry and Sustainable Development</p>
+                                </div>
                             </div>
-            
+
                             <div class="col-md-3 col-sm-6">
-                                <a href="#" class="rotate-box-2 square-icon text-center wow zoomIn" data-wow-delay="0.4s">
-                                    <span class="rotate-box-icon"><i class="fa fa-trophy"></i></span>
-                                    <div class="rotate-box-info">
-                                        <h4>Luminy University Institute of Technology</h4>
-                                        <p>2021 - 2025</p>
-                                        <p>University Bachelor of Technology in networks and telecoms </p>
-                                    </div>
-                                </a>
+                                <div class="education-entry text-center wow zoomIn" data-wow-delay="0.4s">
+                                    <img src="img/portfolio/p3.jpg" alt="Luminy University Institute of Technology logo" class="edu-logo img-responsive center-block">
+                                    <h4>Luminy University Institute of Technology</h4>
+                                    <p>2021 - 2025</p>
+                                    <p>University Bachelor of Technology in networks and telecoms </p>
+                                </div>
                             </div>
-                            
+
                             <div class="col-md-3 col-sm-6">
-                                <a href="#" class="rotate-box-2 square-icon text-center wow zoomIn" data-wow-delay="0.4s">
-                                    <span class="rotate-box-icon"><i class="fa fa-plus"></i></span>
-                                    <div class="rotate-box-info">
-                                        <h4>Coming soon</h4>
-                                        <p></p>
-                                    </div>
-                                </a>
+                                <div class="education-entry text-center wow zoomIn" data-wow-delay="0.4s">
+                                    <img src="img/portfolio/p4.jpg" alt="Coming soon" class="edu-logo img-responsive center-block">
+                                    <h4>Coming soon</h4>
+                                    <p></p>
+                                </div>
                             </div>
-                            
-                            
+
                         </div> <!-- /.row -->
                     </div> <!-- /.container -->
-                    
-                                
+
+
                 </div>
-                <!-- End rotate-box-2 -->
+                <!-- End education logos -->
             </section>
             <!-- End Services -->
             
@@ -444,63 +388,50 @@
                 </div>
                 <!-- End page header-->
             
-                <!-- Begin roatet box-2 -->
-                <div class="rotate-box-2-wrapper">
+                <!-- Begin experience logos -->
+                <div class="experience-wrapper">
                     <div class="container">
                         <div class="row">
                             <div class="col-md-3 col-sm-6">
-                                <a href="#" class="rotate-box-2 square-icon text-center wow zoomIn" data-wow-delay="0">
-                                    <span class="rotate-box-icon"><i class="fa fa-leaf"></i></span>
-                                    <div class="rotate-box-info">
-                                        <h2>WOK UDON</h2>
-                                        <h4>Restaurant Waiter</h4>
-                                    	<p>July 2021 - August 2021</p>
-                                        <p>client installation</p>
-                                    </div>
+                                <a href="exp_wok_udon.html" class="exp-link experience-entry text-center wow zoomIn" data-wow-delay="0">
+                                    <img src="img/portfolio/p5.jpg" alt="WOK UDON logo" class="exp-logo img-responsive center-block">
+                                    <h4>WOK UDON</h4>
+                                    <p>Restaurant Waiter</p>
+                                    <p>July 2021 - August 2021</p>
                                 </a>
                             </div>
-            
+
                             <div class="col-md-3 col-sm-6">
-                                <a href="#" class="rotate-box-2 square-icon text-center wow zoomIn" data-wow-delay="0.2s">
-                                    <span class="rotate-box-icon"><i class="fa fa-pie-chart"></i></span>
-                                    <div class="rotate-box-info">
-                                        <h4>Order Picker</h4>
-                                    	<p>August 2022 - September 2022</p>
-                                        <p>Stock management</p>
-                                    </div>
+                                <a href="exp_order_picker.html" class="exp-link experience-entry text-center wow zoomIn" data-wow-delay="0.2s">
+                                    <img src="img/portfolio/p6.jpg" alt="Order Picker company logo" class="exp-logo img-responsive center-block">
+                                    <h4>Order Picker</h4>
+                                    <p>August 2022 - September 2022</p>
+                                    <p>Stock management</p>
                                 </a>
                             </div>
-            
+
                             <div class="col-md-3 col-sm-6">
-                                <a href="#" class="rotate-box-2 square-icon text-center wow zoomIn" data-wow-delay="0.4s">
-                                    <span class="rotate-box-icon"><i class="fa fa-trophy"></i></span>
-                                    <div class="rotate-box-info">
-                                        <h4>Network and System Technician</h4>
-                                        <p>April 2024 to June 2024</p>
-                                        <p>setting up a directory service Active Directory</p>
-                                    </div>
+                                <a href="exp_network_technician.html" class="exp-link experience-entry text-center wow zoomIn" data-wow-delay="0.4s">
+                                    <img src="img/portfolio/p7.jpg" alt="Network and System Technician logo" class="exp-logo img-responsive center-block">
+                                    <h4>Network and System Technician</h4>
+                                    <p>April 2024 to June 2024</p>
+                                    <p>setting up a directory service Active Directory</p>
                                 </a>
                             </div>
-                            
                             <div class="col-md-3 col-sm-6">
-                                <div class="col-xs-12 col-sm-4 IoT">
-                                                <div class="portfolio_single_content">
-                                                    <img src="img/escape_game.jpg" alt="title"/>
-                                                    <div>
-                                                        <a href="escape_game.html">Escape Game</a>
-                                                        <span>Subtitle</span>
-                                                    </div>
-                                                </div>
-                                            </div>
-                            
-                                
-                
+                                <a href="exp_4connect.html" class="exp-link experience-entry text-center wow zoomIn" data-wow-delay="0.6s">
+                                    <img src="img/portfolio/p8.jpg" alt="4Connect logo" class="exp-logo img-responsive center-block">
+                                    <h4>Network and System Technician</h4>
+                                    <p>17 mars - 29 aout</p>
+                                    <p>4Connect</p>
+                                </a>
+                            </div>
                         </div> <!-- /.row -->
                     </div> <!-- /.container -->
-                    
-                               
+
+
                 </div>
-                <!-- End rotate-box-2 -->
+                <!-- End experience logos -->
             </section>
             <!-- End Services -->
               
@@ -663,8 +594,8 @@
                 
                 
                 
-            <!-- Begin partners -->
-            <section id="partners-section">
+            <!-- Begin certifications -->
+            <section id="certifications-section">
                 <!-- Begin page header-->
                 <div class="page-header-wrapper">
                     <div class="container">
@@ -677,15 +608,35 @@
                 </div>
                 <!-- End page header-->
                 <div class="container">
-                    <div id="owl-partners" class="owl-carousel">
-                        <img src="img/partners/ccna.png" alt="img">
-                        <img src="img/partners/csna.png" alt="img">
-                        <img src="img/partners/secnum.png" alt="img">
-
+                    <div id="owl-certifications" class="owl-carousel">
+                        <a href="ccna.html" class="cert-link">
+                            <figure class="cert-entry" itemscope itemtype="http://schema.org/CreativeWork">
+                                <img src="img/partners/ccna.png" alt="Cisco CCNA certification" class="cert-logo" itemprop="image">
+                                <figcaption itemprop="name">Cisco CCNA</figcaption>
+                            </figure>
+                        </a>
+                        <a href="csna.html" class="cert-link">
+                            <figure class="cert-entry" itemscope itemtype="http://schema.org/CreativeWork">
+                                <img src="img/partners/csna.png" alt="Stormshield CSNA certification" class="cert-logo" itemprop="image">
+                                <figcaption itemprop="name">Stormshield CSNA</figcaption>
+                            </figure>
+                        </a>
+                        <a href="secnum.html" class="cert-link">
+                            <figure class="cert-entry" itemscope itemtype="http://schema.org/CreativeWork">
+                                <img src="img/partners/secnum.png" alt="SecNum Academie certification" class="cert-logo" itemprop="image">
+                                <figcaption itemprop="name">SecNum Académie</figcaption>
+                            </figure>
+                        </a>
+                        <a href="stormshield_security.html" class="cert-link">
+                            <figure class="cert-entry" itemscope itemtype="http://schema.org/CreativeWork">
+                                <img src="img/partners/stormshield.png" alt="Stormshield Security certification" class="cert-logo" itemprop="image">
+                                <figcaption itemprop="name">Stormshield Security</figcaption>
+                            </figure>
+                        </a>
                     </div>
                 </div>
             </section>
-            <!-- End partners -->
+            <!-- End certifications -->
                 
                 
                 

--- a/js/theme.js
+++ b/js/theme.js
@@ -91,8 +91,8 @@ $("#owl-intro-text").owlCarousel({
 })
 
 
-// Partner carousel
-$("#owl-partners").owlCarousel({
+// Certifications carousel
+$("#owl-certifications").owlCarousel({
     items : 4,
     itemsDesktop : [1199,3],
     itemsDesktopSmall : [980,2],

--- a/reseaux.html
+++ b/reseaux.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Réseaux</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Réseaux</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Informations détaillées sur mes compétences en réseaux.</p>
+    </section>
+</body>
+</html>

--- a/secnum.html
+++ b/secnum.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SecNum Académie</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>SecNum Académie</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Informations détaillées sur la certification SecNum Académie.</p>
+    </section>
+</body>
+</html>

--- a/stormshield_security.html
+++ b/stormshield_security.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Stormshield Security</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Stormshield Security</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Informations détaillées sur la certification Stormshield Security.</p>
+    </section>
+</body>
+</html>

--- a/systemes.html
+++ b/systemes.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Systèmes</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Systèmes</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Informations détaillées sur mes compétences en administration de systèmes.</p>
+    </section>
+</body>
+</html>

--- a/telecommunications.html
+++ b/telecommunications.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Télécommunications</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background-color: #f0f0f0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #333;
+            color: #fff;
+            width: 100%;
+            margin-bottom: 60px;
+            border-radius: 5px;
+            margin-left: 30px;
+            margin-right: 30px;
+        }
+        section {
+            margin-bottom: 20px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            width: 70%;
+        }
+        h2 {
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Télécommunications</h1>
+    </header>
+    <section>
+        <h2>Détails</h2>
+        <p>Informations détaillées sur mes compétences en télécommunications.</p>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create dedicated HTML pages for each professional experience and certification
- link experience entries and certification items on the home page to their detail pages
- add Network and System Technician position at 4Connect
- style links for experience and certification blocks

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a8f91da7c832389fdb07eb7ac5855