### PR TITLE
Add education pages with cyber theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1158,7 +1158,7 @@ p.subtitle {
     margin-bottom: 15px;
     object-fit: contain;
 }
-.exp-link, .cert-link {
+.exp-link, .cert-link, .edu-link {
     display: block;
     color: inherit;
     text-decoration: none;

--- a/efrei_paris.html
+++ b/efrei_paris.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Efrei Paris</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #0d1117;
+            color: #e0e0e0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #1f2937;
+            color: #fff;
+            padding: 20px;
+            border-radius: 5px;
+            width: 100%;
+            margin-bottom: 40px;
+        }
+        section {
+            width: 90%;
+            max-width: 1000px;
+            margin-bottom: 30px;
+            background-color: #161b22;
+            padding: 20px;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.6);
+        }
+        h2 {
+            color: #60a5fa;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 20px;
+        }
+        .card {
+            background-color: #1e293b;
+            border-radius: 5px;
+            padding: 15px;
+            box-shadow: 0 0 5px rgba(0,0,0,0.2);
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 8px 15px rgba(0,0,0,0.5);
+        }
+        .cta {
+            background-color: #1f2937;
+            color: #fff;
+            text-align: center;
+        }
+        .cta a {
+            color: #1e90ff;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Efrei Paris</h1>
+        <p>Cycle ingénieur en cybersécurité</p>
+    </header>
+    <section>
+        <h2>Présentation</h2>
+        <p>Efrei Paris est une école d'ingénieurs spécialisée dans le numérique. J'y poursuis un cursus orienté cybersécurité afin de renforcer mes compétences techniques et organisationnelles.</p>
+    </section>
+    <section>
+        <h2>Objectifs de la formation</h2>
+        <div class="grid">
+            <div class="card">
+                <h3>Expertise technique</h3>
+                <p>Approfondissement des protocoles de sécurité et des pratiques d'audit.</p>
+            </div>
+            <div class="card">
+                <h3>Gestion de projets</h3>
+                <p>Conduite de projets en équipe autour des enjeux de cybersécurité.</p>
+            </div>
+        </div>
+    </section>
+    <section class="cta">
+        <p><a href="index.html">Retour au portfolio</a></p>
+    </section>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -354,37 +354,37 @@
                     <div class="container">
                         <div class="row">
                             <div class="col-md-3 col-sm-6">
-                                <div class="education-entry text-center wow zoomIn" data-wow-delay="0">
+                                <a href="longchamp.html" class="edu-link education-entry text-center wow zoomIn" data-wow-delay="0">
                                     <img src="img/portfolio/p1.jpg" alt="Longchamp Public Middle School logo" class="edu-logo img-responsive center-block">
                                     <h4>Longchamp Public Middle School</h4>
                                     <p>2014 - 2018</p>
-                                </div>
+                                </a>
                             </div>
 
                             <div class="col-md-3 col-sm-6">
-                                <div class="education-entry text-center wow zoomIn" data-wow-delay="0.2s">
+                                <a href="rempart.html" class="edu-link education-entry text-center wow zoomIn" data-wow-delay="0.2s">
                                     <img src="img/portfolio/p2.jpg" alt="High School of Rempart logo" class="edu-logo img-responsive center-block">
                                     <h4>High School of Rempart</h4>
                                     <p>2019 - 2021</p>
                                     <p>High School Diploma in Science and Technology for Industry and Sustainable Development</p>
-                                </div>
+                                </a>
                             </div>
 
                             <div class="col-md-3 col-sm-6">
-                                <div class="education-entry text-center wow zoomIn" data-wow-delay="0.4s">
+                                <a href="luminy.html" class="edu-link education-entry text-center wow zoomIn" data-wow-delay="0.4s">
                                     <img src="img/portfolio/p3.jpg" alt="Luminy University Institute of Technology logo" class="edu-logo img-responsive center-block">
                                     <h4>Luminy University Institute of Technology</h4>
                                     <p>2021 - 2025</p>
                                     <p>University Bachelor of Technology in networks and telecoms </p>
-                                </div>
+                                </a>
                             </div>
 
                             <div class="col-md-3 col-sm-6">
-                                <div class="education-entry text-center wow zoomIn" data-wow-delay="0.4s">
-                                    <img src="img/portfolio/p4.jpg" alt="Coming soon" class="edu-logo img-responsive center-block">
-                                    <h4>Coming soon</h4>
-                                    <p></p>
-                                </div>
+                                <a href="efrei_paris.html" class="edu-link education-entry text-center wow zoomIn" data-wow-delay="0.4s">
+                                    <img src="img/portfolio/p4.jpg" alt="Efrei Paris logo" class="edu-logo img-responsive center-block">
+                                    <h4>Efrei Paris</h4>
+                                    <p>Cycle ingénieur cybersécurité</p>
+                                </a>
                             </div>
 
                         </div> <!-- /.row -->

--- a/longchamp.html
+++ b/longchamp.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Collège Longchamp</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #0d1117;
+            color: #e0e0e0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #1f2937;
+            color: #fff;
+            padding: 20px;
+            border-radius: 5px;
+            width: 100%;
+            margin-bottom: 40px;
+        }
+        section {
+            width: 90%;
+            max-width: 1000px;
+            margin-bottom: 30px;
+            background-color: #161b22;
+            padding: 20px;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.6);
+        }
+        h2 {
+            color: #60a5fa;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 20px;
+        }
+        .card {
+            background-color: #1e293b;
+            border-radius: 5px;
+            padding: 15px;
+            box-shadow: 0 0 5px rgba(0,0,0,0.2);
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 8px 15px rgba(0,0,0,0.5);
+        }
+        .cta {
+            background-color: #1f2937;
+            color: #fff;
+            text-align: center;
+        }
+        .cta a {
+            color: #1e90ff;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Collège Longchamp</h1>
+        <p>Marseille, 2014 - 2018</p>
+    </header>
+    <section>
+        <h2>Présentation</h2>
+        <p>Cette période au collège Longchamp m'a initié aux disciplines scientifiques et à mes premiers projets numériques.</p>
+    </section>
+    <section>
+        <h2>Moments clés</h2>
+        <div class="grid">
+            <div class="card">
+                <h3>Ateliers technologiques</h3>
+                <p>Découverte de la robotique et de la programmation à travers des activités ludiques.</p>
+            </div>
+            <div class="card">
+                <h3>Vie associative</h3>
+                <p>Participation aux clubs scolaires et actions solidaires.</p>
+            </div>
+        </div>
+    </section>
+    <section class="cta">
+        <p><a href="index.html">Retour au portfolio</a></p>
+    </section>
+</body>
+</html>

--- a/luminy.html
+++ b/luminy.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>IUT d'Aix-Marseille - Luminy</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #0d1117;
+            color: #e0e0e0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #1f2937;
+            color: #fff;
+            padding: 20px;
+            border-radius: 5px;
+            width: 100%;
+            margin-bottom: 40px;
+        }
+        section {
+            width: 90%;
+            max-width: 1000px;
+            margin-bottom: 30px;
+            background-color: #161b22;
+            padding: 20px;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.6);
+        }
+        h2 {
+            color: #60a5fa;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 20px;
+        }
+        .card {
+            background-color: #1e293b;
+            border-radius: 5px;
+            padding: 15px;
+            box-shadow: 0 0 5px rgba(0,0,0,0.2);
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 8px 15px rgba(0,0,0,0.5);
+        }
+        .cta {
+            background-color: #1f2937;
+            color: #fff;
+            text-align: center;
+        }
+        .cta a {
+            color: #1e90ff;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>IUT d'Aix-Marseille - Site de Luminy</h1>
+        <p>BUT Réseaux &amp; Télécoms (2021 - 2025)</p>
+    </header>
+    <section>
+        <h2>Présentation</h2>
+        <p>Au sein de l'IUT, j'ai consolidé mes compétences en administration réseau et en développement d'outils orientés cybersécurité.</p>
+    </section>
+    <section>
+        <h2>Projets marquants</h2>
+        <div class="grid">
+            <div class="card">
+                <h3>Infrastructure Cisco</h3>
+                <p>Configuration avancée de routage et de commutation sur équipement professionnel.</p>
+            </div>
+            <div class="card">
+                <h3>Veille sécurité</h3>
+                <p>Réalisation d'études de vulnérabilités et mise en place d'outils de monitoring.</p>
+            </div>
+        </div>
+    </section>
+    <section class="cta">
+        <p><a href="index.html">Retour au portfolio</a></p>
+    </section>
+</body>
+</html>

--- a/rempart.html
+++ b/rempart.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Lycée du Rempart</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #0d1117;
+            color: #e0e0e0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        header {
+            text-align: center;
+            background-color: #1f2937;
+            color: #fff;
+            padding: 20px;
+            border-radius: 5px;
+            width: 100%;
+            margin-bottom: 40px;
+        }
+        section {
+            width: 90%;
+            max-width: 1000px;
+            margin-bottom: 30px;
+            background-color: #161b22;
+            padding: 20px;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.6);
+        }
+        h2 {
+            color: #60a5fa;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 20px;
+        }
+        .card {
+            background-color: #1e293b;
+            border-radius: 5px;
+            padding: 15px;
+            box-shadow: 0 0 5px rgba(0,0,0,0.2);
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 8px 15px rgba(0,0,0,0.5);
+        }
+        .cta {
+            background-color: #1f2937;
+            color: #fff;
+            text-align: center;
+        }
+        .cta a {
+            color: #1e90ff;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Lycée du Rempart</h1>
+        <p>Marseille, 2019 - 2021 &ndash; Baccalauréat STI2D option SIN</p>
+    </header>
+    <section>
+        <h2>Présentation</h2>
+        <p>Au lycée du Rempart, j'ai approfondi mes connaissances techniques en électronique et informatique tout en développant une forte culture scientifique.</p>
+    </section>
+    <section>
+        <h2>Moments clés</h2>
+        <div class="grid">
+            <div class="card">
+                <h3>Projet de terminale</h3>
+                <p>Réalisation d'un système embarqué dédié à la domotique.</p>
+            </div>
+            <div class="card">
+                <h3>Approche pédagogique</h3>
+                <p>Mise en pratique des cours via des travaux dirigés orientés réseaux et sécurité.</p>
+            </div>
+        </div>
+    </section>
+    <section class="cta">
+        <p><a href="index.html">Retour au portfolio</a></p>
+    </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- added dedicated pages for Longchamp, Rempart, Luminy and Efrei Paris
- replaced placeholder in education section with Efrei Paris and linked all entries
- extended CSS to support `edu-link` anchors

## Testing
- `npm test` *(fails: package.json missing)*
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_685af83257048323a54bc783c7efe0db