### PR TITLE
Harmonise experience pages with cyber theme

### DIFF
--- a/exp_4connect.html
+++ b/exp_4connect.html
@@ -1,46 +1,67 @@
 <!DOCTYPE html>
-<html>
+<html lang="fr">
 <head>
-    <title>4Connect - Network and System Technician</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>4Connect</title>
     <style>
         body {
             font-family: Arial, sans-serif;
+            background-color: #0d1117;
+            color: #e0e0e0;
             padding: 20px;
-            background-color: #f0f0f0;
             display: flex;
             flex-direction: column;
             align-items: center;
         }
         header {
             text-align: center;
-            background-color: #333;
+            background-color: #1f2937;
             color: #fff;
-            width: 100%;
-            margin-bottom: 60px;
+            padding: 20px;
             border-radius: 5px;
-            margin-left: 30px;
-            margin-right: 30px;
+            width: 100%;
+            margin-bottom: 40px;
         }
         section {
-            margin-bottom: 20px;
+            width: 90%;
+            max-width: 1000px;
+            margin-bottom: 30px;
+            background-color: #161b22;
             padding: 20px;
-            background-color: #fff;
             border-radius: 5px;
-            box-shadow: 0 0 10px rgba(0,0,0,0.1);
-            width: 70%;
+            box-shadow: 0 0 10px rgba(0,0,0,0.6);
         }
         h2 {
-            color: #333;
+            color: #60a5fa;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        .cta {
+            background-color: #1f2937;
+            color: #fff;
+            text-align: center;
+        }
+        .cta a {
+            color: #1e90ff;
         }
     </style>
 </head>
 <body>
     <header>
         <h1>4Connect</h1>
+        <p>Technicien réseau &amp; système - 2023</p>
     </header>
     <section>
-        <h2>Détails</h2>
-        <p>Network and System Technician from 17 mars to 29 aout.</p>
+        <h2>Organisme d'accueil</h2>
+        <p>Mission effectuée pour l'association Bonneveine-Saint Joseph au sein de la Clinique Bonneveine.</p>
+    </section>
+    <section>
+        <h2>Projets réalisés</h2>
+        <p>Maintenance de l'infrastructure existante et assistance utilisateurs sur site.</p>
+    </section>
+    <section class="cta">
+        <p><a href="index.html">Retour au portfolio</a></p>
     </section>
 </body>
 </html>

--- a/exp_network_technician.html
+++ b/exp_network_technician.html
@@ -1,46 +1,67 @@
 <!DOCTYPE html>
-<html>
+<html lang="fr">
 <head>
-    <title>Network and System Technician</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Technicien Réseaux</title>
     <style>
         body {
             font-family: Arial, sans-serif;
+            background-color: #0d1117;
+            color: #e0e0e0;
             padding: 20px;
-            background-color: #f0f0f0;
             display: flex;
             flex-direction: column;
             align-items: center;
         }
         header {
             text-align: center;
-            background-color: #333;
+            background-color: #1f2937;
             color: #fff;
-            width: 100%;
-            margin-bottom: 60px;
+            padding: 20px;
             border-radius: 5px;
-            margin-left: 30px;
-            margin-right: 30px;
+            width: 100%;
+            margin-bottom: 40px;
         }
         section {
-            margin-bottom: 20px;
+            width: 90%;
+            max-width: 1000px;
+            margin-bottom: 30px;
+            background-color: #161b22;
             padding: 20px;
-            background-color: #fff;
             border-radius: 5px;
-            box-shadow: 0 0 10px rgba(0,0,0,0.1);
-            width: 70%;
+            box-shadow: 0 0 10px rgba(0,0,0,0.6);
         }
         h2 {
-            color: #333;
+            color: #60a5fa;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        .cta {
+            background-color: #1f2937;
+            color: #fff;
+            text-align: center;
+        }
+        .cta a {
+            color: #1e90ff;
         }
     </style>
 </head>
 <body>
     <header>
-        <h1>Network and System Technician</h1>
+        <h1>Technicien Réseaux</h1>
+        <p>Stage - 2024</p>
     </header>
     <section>
-        <h2>Détails</h2>
-        <p>Implemented an Active Directory service in 2024.</p>
+        <h2>Organisme d'accueil</h2>
+        <p>Intégré au service informatique d'une entreprise de services, j'ai participé à la gestion quotidienne du réseau.</p>
+    </section>
+    <section>
+        <h2>Projets réalisés</h2>
+        <p>Mise en place d'un service Active Directory et déploiement de solutions de sauvegarde.</p>
+    </section>
+    <section class="cta">
+        <p><a href="index.html">Retour au portfolio</a></p>
     </section>
 </body>
 </html>

--- a/exp_order_picker.html
+++ b/exp_order_picker.html
@@ -1,46 +1,67 @@
 <!DOCTYPE html>
-<html>
+<html lang="fr">
 <head>
-    <title>Order Picker Experience</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Order Picker</title>
     <style>
         body {
             font-family: Arial, sans-serif;
+            background-color: #0d1117;
+            color: #e0e0e0;
             padding: 20px;
-            background-color: #f0f0f0;
             display: flex;
             flex-direction: column;
             align-items: center;
         }
         header {
             text-align: center;
-            background-color: #333;
+            background-color: #1f2937;
             color: #fff;
-            width: 100%;
-            margin-bottom: 60px;
+            padding: 20px;
             border-radius: 5px;
-            margin-left: 30px;
-            margin-right: 30px;
+            width: 100%;
+            margin-bottom: 40px;
         }
         section {
-            margin-bottom: 20px;
+            width: 90%;
+            max-width: 1000px;
+            margin-bottom: 30px;
+            background-color: #161b22;
             padding: 20px;
-            background-color: #fff;
             border-radius: 5px;
-            box-shadow: 0 0 10px rgba(0,0,0,0.1);
-            width: 70%;
+            box-shadow: 0 0 10px rgba(0,0,0,0.6);
         }
         h2 {
-            color: #333;
+            color: #60a5fa;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        .cta {
+            background-color: #1f2937;
+            color: #fff;
+            text-align: center;
+        }
+        .cta a {
+            color: #1e90ff;
         }
     </style>
 </head>
 <body>
     <header>
         <h1>Order Picker</h1>
+        <p>Préparateur de commandes - 2022</p>
     </header>
     <section>
-        <h2>Détails</h2>
-        <p>Handled stock management tasks in 2022.</p>
+        <h2>Organisme d'accueil</h2>
+        <p>Expérience réalisée au sein d'un entrepôt logistique spécialisé dans la distribution de biens de consommation.</p>
+    </section>
+    <section>
+        <h2>Projets réalisés</h2>
+        <p>Gestion des stocks et préparation des commandes destinées à l'expédition.</p>
+    </section>
+    <section class="cta">
+        <p><a href="index.html">Retour au portfolio</a></p>
     </section>
 </body>
 </html>

--- a/exp_wok_udon.html
+++ b/exp_wok_udon.html
@@ -1,46 +1,67 @@
 <!DOCTYPE html>
-<html>
+<html lang="fr">
 <head>
-    <title>WOK UDON Experience</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WOK UDON</title>
     <style>
         body {
             font-family: Arial, sans-serif;
+            background-color: #0d1117;
+            color: #e0e0e0;
             padding: 20px;
-            background-color: #f0f0f0;
             display: flex;
             flex-direction: column;
             align-items: center;
         }
         header {
             text-align: center;
-            background-color: #333;
+            background-color: #1f2937;
             color: #fff;
-            width: 100%;
-            margin-bottom: 60px;
+            padding: 20px;
             border-radius: 5px;
-            margin-left: 30px;
-            margin-right: 30px;
+            width: 100%;
+            margin-bottom: 40px;
         }
         section {
-            margin-bottom: 20px;
+            width: 90%;
+            max-width: 1000px;
+            margin-bottom: 30px;
+            background-color: #161b22;
             padding: 20px;
-            background-color: #fff;
             border-radius: 5px;
-            box-shadow: 0 0 10px rgba(0,0,0,0.1);
-            width: 70%;
+            box-shadow: 0 0 10px rgba(0,0,0,0.6);
         }
         h2 {
-            color: #333;
+            color: #60a5fa;
+            margin-bottom: 20px;
+            text-align: center;
+        }
+        .cta {
+            background-color: #1f2937;
+            color: #fff;
+            text-align: center;
+        }
+        .cta a {
+            color: #1e90ff;
         }
     </style>
 </head>
 <body>
     <header>
         <h1>WOK UDON</h1>
+        <p>Serveur en restaurant - Été 2021</p>
     </header>
     <section>
-        <h2>Détails</h2>
-        <p>Restaurant waiter during the summer of 2021.</p>
+        <h2>Organisme d'accueil</h2>
+        <p>WOK UDON est un restaurant asiatique dynamique où j'ai travaillé durant l'été 2021.</p>
+    </section>
+    <section>
+        <h2>Projets réalisés</h2>
+        <p>Gestion du service en salle et prise de commandes, tout en assurant une bonne expérience client.</p>
+    </section>
+    <section class="cta">
+        <p><a href="index.html">Retour au portfolio</a></p>
     </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle each experience page with a consistent dark cyber theme
- add sections describing the host organisation and projects
- include a call to action returning to the portfolio

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685afdcfe7d4832388b781532be8a7c9