### PR TITLE
Add certification categories

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -739,6 +739,13 @@ a.rotate-box-1:hover, a.rotate-box-2:hover {
         margin-bottom: 15px;
         object-fit: contain;
 }
+.cert-category {
+        margin-top: 40px;
+        margin-bottom: 20px;
+        font-size: 24px;
+        font-weight: 600;
+        text-align: center;
+}
 /* ===== End certifications ===== */
 
 

--- a/index.html
+++ b/index.html
@@ -637,24 +637,12 @@
                 </div>
                 <!-- End page header-->
                 <div class="container">
-                    <div id="owl-certifications" class="owl-carousel">
-
-                        <a href="ccna.html" class="cert-link">
-                            <figure class="cert-entry" itemscope itemtype="http://schema.org/CreativeWork">
-                                <img src="img/partners/ccna.png" alt="Cisco CCNA certification" class="cert-logo" itemprop="image">
-                                <figcaption itemprop="name">Cisco CCNA</figcaption>
-                            </figure>
-                        </a>
+                    <h3 class="cert-category">Stormshield</h3>
+                    <div id="owl-certifications-stormshield" class="owl-carousel">
                         <a href="csna.html" class="cert-link">
                             <figure class="cert-entry" itemscope itemtype="http://schema.org/CreativeWork">
                                 <img src="img/partners/csna.png" alt="Stormshield CSNA certification" class="cert-logo" itemprop="image">
                                 <figcaption itemprop="name">Stormshield CSNA</figcaption>
-                            </figure>
-                        </a>
-                        <a href="secnum.html" class="cert-link">
-                            <figure class="cert-entry" itemscope itemtype="http://schema.org/CreativeWork">
-                                <img src="img/partners/secnum.png" alt="SecNum Academie certification" class="cert-logo" itemprop="image">
-                                <figcaption itemprop="name">SecNum Académie</figcaption>
                             </figure>
                         </a>
                         <a href="stormshield_security.html" class="cert-link">
@@ -663,7 +651,26 @@
                                 <figcaption itemprop="name">Stormshield Security</figcaption>
                             </figure>
                         </a>
+                    </div>
 
+                    <h3 class="cert-category">Cisco</h3>
+                    <div id="owl-certifications-cisco" class="owl-carousel">
+                        <a href="ccna.html" class="cert-link">
+                            <figure class="cert-entry" itemscope itemtype="http://schema.org/CreativeWork">
+                                <img src="img/partners/ccna.png" alt="Cisco CCNA certification" class="cert-logo" itemprop="image">
+                                <figcaption itemprop="name">Cisco CCNA</figcaption>
+                            </figure>
+                        </a>
+                    </div>
+
+                    <h3 class="cert-category">ANSSI</h3>
+                    <div id="owl-certifications-anssi" class="owl-carousel">
+                        <a href="secnum.html" class="cert-link">
+                            <figure class="cert-entry" itemscope itemtype="http://schema.org/CreativeWork">
+                                <img src="img/partners/secnum.png" alt="SecNum Academie certification" class="cert-logo" itemprop="image">
+                                <figcaption itemprop="name">SecNum Académie</figcaption>
+                            </figure>
+                        </a>
                     </div>
                 </div>
             </section>

--- a/js/theme.js
+++ b/js/theme.js
@@ -91,8 +91,8 @@ $("#owl-intro-text").owlCarousel({
 })
 
 
-// Certifications carousel
-$("#owl-certifications").owlCarousel({
+// Certifications carousels
+$("#owl-certifications-stormshield, #owl-certifications-cisco, #owl-certifications-anssi").owlCarousel({
     items : 4,
     itemsDesktop : [1199,3],
     itemsDesktopSmall : [980,2],


### PR DESCRIPTION
## Summary
- reorganize certifications by category (Stormshield, Cisco, ANSSI)
- init multiple carousels for certification categories
- style certification category headers

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b076897508323a90a8d456ccc12ef